### PR TITLE
Rename replicated rdb file only if it is valid.

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1257,12 +1257,6 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
             killRDBChild();
         }
 
-        if (rename(server.repl_transfer_tmpfile,server.rdb_filename) == -1) {
-            serverLog(LL_WARNING,"Failed trying to rename the temp DB into %s in MASTER <-> REPLICA synchronization: %s", 
-			    server.rdb_filename, strerror(errno));
-            cancelReplicationHandshake();
-            return;
-        }
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Flushing old data");
         /* We need to stop any AOFRW fork before flusing and parsing
          * RDB, otherwise we'll create a copy-on-write disaster. */
@@ -1279,7 +1273,7 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
         aeDeleteFileEvent(server.el,server.repl_transfer_s,AE_READABLE);
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Loading DB in memory");
         rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
-        if (rdbLoad(server.rdb_filename,&rsi) != C_OK) {
+        if (rdbLoad(server.repl_transfer_tmpfile,&rsi) != C_OK) {
             serverLog(LL_WARNING,"Failed trying to load the MASTER synchronization DB from disk");
             cancelReplicationHandshake();
             /* Re-enable the AOF if we disabled it earlier, in order to restore
@@ -1287,6 +1281,16 @@ void readSyncBulkPayload(aeEventLoop *el, int fd, void *privdata, int mask) {
             if (aof_is_enabled) restartAOF();
             return;
         }
+
+        serverLog(LL_NOTICE, "MASTER <-> SLAVE sync: Renaming %s file to %s",
+                  server.repl_transfer_tmpfile, server.rdb_filename");
+        if (rename(server.repl_transfer_tmpfile,server.rdb_filename) == -1) {
+            serverLog(LL_WARNING,"Failed trying to rename the temp DB into %s in MASTER <-> REPLICA synchronization: %s", 
+			    server.rdb_filename, strerror(errno));
+            cancelReplicationHandshake();
+            return;
+        }
+
         /* Final setup of the connected slave <- master link */
         zfree(server.repl_transfer_tmpfile);
         close(server.repl_transfer_fd);


### PR DESCRIPTION
If leader has a memory corruption and managed to replicate a corrupted dump.rdb to all of it's followers, there is a chance for data loss. The follower renames temporary dump.rdb file before doing a rdbLoad and checking the validity of newly replicated file. Fixed this by checking validity of newly replicated dump.rdb file before attempting to rename the temporary file.